### PR TITLE
Launcher3: fix option icons for light theme

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -43,9 +43,9 @@
     <color name="container_fastscroll_thumb_active_color">#009688</color>
 
     <!-- Options -->
-    <color name="ic_setting_icon_color">#FF374248</color>
-    <color name="ic_wallpaper_icon_color">#FF374248</color>
-    <color name="ic_widget_icon_color">#FF374248</color>
+    <color name="ic_setting_icon_color">#FFFFFFFF</color>
+    <color name="ic_wallpaper_icon_color">#FFFFFFFF</color>
+    <color name="ic_widget_icon_color">#FFFFFFFF</color>
 
     <!-- All Apps -->
     <color name="all_apps_grid_section_text_color">#009688</color>


### PR DESCRIPTION
Those values should be fully white. I changed this a few days ago in the commit, but as far as you cherry-picked a lot of days ago you did not notice. Enjoy!